### PR TITLE
Make clientCommands more robust towards addition/removal of commands

### DIFF
--- a/src/client-commands.ts
+++ b/src/client-commands.ts
@@ -1,8 +1,8 @@
 "use strict";
 
 // Metals expects clients to implement the following commands: https://scalameta.org/metals/docs/editors/new-editor.html#metals-client-commands
-export namespace ClientCommands {
-  export const TOGGLE_LOGS = "metals-logs-toggle";
-  export const FOCUS_DIAGNOSTICS = "metals-diagnostics-focus";
-  export const RUN_DOCTOR = "metals-doctor-run";
-}
+export const ClientCommands = {
+  toggleLogs: "metals-logs-toggle",
+  focusDiagnostics: "metals-diagnostics-focus",
+  runDoctor: "metals-doctor-run"
+};


### PR DESCRIPTION
This refactors makes TS complain whenever you add/remove/edit any item of `ClientCommands` and you forget to update the command registration.

Try changing any key (add/remove/edit) in `ClientCommands` and you'll get an error in `extension.ts`